### PR TITLE
\not -> \neg

### DIFF
--- a/vis/src/utils.js
+++ b/vis/src/utils.js
@@ -120,7 +120,7 @@ function replacer(match, p1, p2, p3, offset, string) {
         '∧': '$\\wedge$',
         '∨': '$\\vee$',
         '⇒': '$\\implies$',
-        '¬': '$\\not$',
+        '¬': '$\\neg$',
         '≈': '$\\approx$',
         '_': '\\_',
         '>': '$>$',


### PR DESCRIPTION
The negation symbol got converted to `\not`, when copying query to LaTeX, it should instead be `\neg`

### `\not`
($\not$ model\_1 = model\_2)
### `\neg`
($\neg$ model\_1 = model\_2)